### PR TITLE
Use the build:compiled hook for nuxt 2 compatibility, fixes #12

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -99,7 +99,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (isNuxt3()) return
 
     // @ts-expect-error TODO: use @nuxt/bridge-schema
-    nuxt.hook('generate:done', async () => {
+    nuxt.hook('build:compiled', async () => {
       // @ts-expect-error TODO: use @nuxt/bridge-schema
       await copyLibFiles(join(nuxt.options.generate.dir, options.lib))
     })


### PR DESCRIPTION
Apparently the `generate:done` hook doesn't (at least not for me) always run when i build nuxt 2 projects. `build:compiled` seems to do the trick